### PR TITLE
Update cors policy to include allowed domains

### DIFF
--- a/cmd/calidum-rotae-service/config/config.go
+++ b/cmd/calidum-rotae-service/config/config.go
@@ -18,6 +18,9 @@ const (
 	// OTEL Tracer settings
 	FlagOTELOtlpExporterHost = "otel_otlp_exporter_host"
 	FlagOTELOtlpExporterPort = "otel_otlp_exporter_port"
+
+	// Allowed domains settings for CORS
+	FlagAllowedDomains = "allowed_domains"
 )
 
 func SetFlags(cmd *cobra.Command) {
@@ -32,6 +35,8 @@ func SetFlags(cmd *cobra.Command) {
 
 	cmd.Flags().String(FlagOTELOtlpExporterHost, "localhost", "The OTEL OTLP exporter host to connect to")
 	cmd.Flags().String(FlagOTELOtlpExporterPort, "4318", "The OTEL OTLP exporter port to connect to")
+
+	cmd.Flags().StringSlice(FlagAllowedDomains, []string{"*"}, "The allowed domains for CORS")
 
 	cmd.MarkFlagRequired(FlagPort)
 }

--- a/cmd/calidum-rotae-service/server/http.go
+++ b/cmd/calidum-rotae-service/server/http.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 
 	"github.com/clubcedille/calidum-rotae-backend/cmd/calidum-rotae-service/config"
 	"github.com/clubcedille/calidum-rotae-backend/cmd/calidum-rotae-service/instrumentation"
@@ -110,8 +111,14 @@ func setupCorsConfig(v *viper.Viper) cors.Config {
 }
 
 func CorsOriginFilter(allowedDomains []string) func(string) bool {
-	return func(origin string) bool {
+    return func(origin string) bool {
         for _, allowed := range allowedDomains {
+            // Handle wildcard domains
+            match, _ := filepath.Match(allowed, origin)
+            if match {
+                return true
+            }
+
             if origin == allowed {
                 return true
             }

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -114,7 +114,7 @@ services:
       "--email_provider_port", "4000",
       "--otel_otlp_exporter_host", "otel-collector",
       "--otel_otlp_exporter_port", "4318",
-      "--allowed_domains", "http://localhost",
+      "--allowed_domains", "http://localhost*",
     ]
 
 volumes:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -114,6 +114,7 @@ services:
       "--email_provider_port", "4000",
       "--otel_otlp_exporter_host", "otel-collector",
       "--otel_otlp_exporter_port", "4318",
+      "--allowed_domains", "http://localhost",
     ]
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
       "--email_provider_port", "4000",
       "--otel_otlp_exporter_host", "localhost",
       "--otel_otlp_exporter_port", "4318",
-      "--allowed_domains", "http://localhost",
+      "--allowed_domains", "http://localhost*",
     ]
     
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,7 @@ services:
       "--email_provider_port", "4000",
       "--otel_otlp_exporter_host", "localhost",
       "--otel_otlp_exporter_port", "4318",
+      "--allowed_domains", "http://localhost,http://localhost:1313",
     ]
     
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
       "--email_provider_port", "4000",
       "--otel_otlp_exporter_host", "localhost",
       "--otel_otlp_exporter_port", "4318",
-      "--allowed_domains", "http://localhost,http://localhost:1313",
+      "--allowed_domains", "http://localhost",
     ]
     
 networks:


### PR DESCRIPTION
- adds entrypoint parameter `--allowed_domains` that allows specifying a list of domains authorized to make requests to the service. This addition is particularly crucial for our static web applications, which will be utilizing this service but cannot conceal API keys. By defining accepted domains, we ensure a more secure and controlled interaction between our web apps and the calidum-rotae service, aligning with best practices in API security.

Todo before merging : 
- [x] Handle wildcards in --allowed_domains
 
Todo on cluster repository : 
- Update entrypoint parameters to include : 
"--allowed_domains", "https://*.cedille.club,https://*.etsmtl.ca"